### PR TITLE
Fix hora validation for missing slot

### DIFF
--- a/actions/actions.py
+++ b/actions/actions.py
@@ -85,17 +85,23 @@ class ValidateAgendarCitaForm(FormValidationAction):
             return {"fecha": None}
 
     async def validate_hora(self, slot_value, dispatcher, tracker, domain):
+        if not slot_value:
+            dispatcher.utter_message(response="utter_error_hora")
+            return {"hora": None}
+
         try:
-            hora_str = ''.join(filter(lambda x: x.isdigit() or x == ':', slot_value))
-            parsed = parse(hora_str, settings={'TIMEZONE': TZ.zone})
+            hora_str = ''.join(
+                filter(lambda x: x.isdigit() or x == ':', slot_value)
+            )
+            parsed = parse(hora_str, settings={"TIMEZONE": TZ.zone})
             if not parsed:
                 raise ValueError
             hora = parsed.time()
-            if hora < time(8,0) or hora > time(18,0):
+            if hora < time(8, 0) or hora > time(18, 0):
                 dispatcher.utter_message(response="utter_error_hora")
                 return {"hora": None}
             return {"hora": hora.strftime("%H:%M")}
-        except Exception as e:
+        except Exception:
             dispatcher.utter_message(response="utter_error_hora")
             return {"hora": None}
 


### PR DESCRIPTION
## Summary
- handle empty `hora` slot in the appointment form validator

## Testing
- `python -m py_compile backend.py actions/actions.py`
- `flake8 actions/actions.py`

------
https://chatgpt.com/codex/tasks/task_e_68524c8dc270832f93733ec6d84508c4