### PR TITLE
Refactor intent names and update training data

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Cuando un usuario agenda una cita y la confirma, el bot registra el servicio,
 fecha y hora en la base de datos SQLite `usuarios.db` dentro de la tabla
 `citas`. El número de teléfono enviado por el frontend se usa como identificador
 del usuario, por lo que las citas quedan asociadas a cada cuenta y pueden
-consultarse posteriormente mediante la intención `consultar_cita`.
+consultarse posteriormente mediante la intención `consultar_cita_activa`.
 
 ## Persistencia del historial de conversaciones
 

--- a/actions/actions.py
+++ b/actions/actions.py
@@ -162,6 +162,8 @@ class ActionCancelarCita(Action):
         return [SlotSet("servicio", None), SlotSet("fecha", None), SlotSet("hora", None)]
 
 class ActionMostrarHistorial(Action):
+    """Devuelve las citas pasadas del usuario cuando se activa el
+    intent `consultar_historial_citas`."""
     def name(self) -> str:
         return "action_mostrar_historial"
 
@@ -201,6 +203,8 @@ class ActionMostrarHistorial(Action):
         return []
 
 class ActionConsultarCita(Action):
+    """Informa la próxima cita del usuario cuando se activa el
+    intent `consultar_cita_activa`."""
     def name(self) -> str:
         return "action_consultar_cita"
 

--- a/data/nlu.yml
+++ b/data/nlu.yml
@@ -32,25 +32,11 @@ nlu:
     - quiero mover mi cita
     - reprograma mi cita
 
-- intent: consultar_cita
-  examples: |
-    - ¿cuándo es mi próxima cita?
-    - revisa mis citas agendadas
-    - quiero ver mi próxima cita
-    - muéstrame mi próxima cita
-    - consulta mi próxima cita
-
 - intent: consultar_servicios
   examples: |
     - ¿qué servicios ofrecen?
     - muéstrame sus servicios disponibles
     - qué servicios tiene el taller
-
-- intent: consultar_horarios
-  examples: |
-    - qué horarios tienen disponibles
-    - quiero ver los horarios
-    - muéstrame horarios disponibles
 
 - intent: confirmar
   examples: |
@@ -153,14 +139,6 @@ nlu:
     - ¿Por qué vibra el volante?
     - ¿Cuál es la presión correcta de las llantas?
     - ¿Qué hago si se prende el check engine?
-
-- intent: mostrar_historial
-  examples: |
-    - historial
-    - ver historial de citas
-    - mostrar mi historial
-    - quiero ver mis citas anteriores
-    - muéstrame mis citas pasadas
 
 - intent: consultar_historial_citas
   examples: |

--- a/data/rules.yml
+++ b/data/rules.yml
@@ -36,7 +36,7 @@ rules:
 
 - rule: Consultar horarios
   steps:
-    - intent: consultar_horarios
+    - intent: consultar_horarios_disponibles
     - action: utter_horarios
 
 - rule: Manejar despedida
@@ -61,5 +61,10 @@ rules:
 
 - rule: Consultar cita
   steps:
-    - intent: consultar_cita
+    - intent: consultar_cita_activa
     - action: action_consultar_cita
+
+- rule: Consultar historial
+  steps:
+    - intent: consultar_historial_citas
+    - action: action_mostrar_historial

--- a/data/stories.yml
+++ b/data/stories.yml
@@ -31,9 +31,9 @@ stories:
     - intent: agradecer
     - action: utter_agradecimiento
 
-- story: consultar_horarios
+  - story: consultar_horarios
   steps:
-    - intent: consultar_horarios
+    - intent: consultar_horarios_disponibles
     - action: utter_horarios
 
 - story: duracion_servicios
@@ -46,12 +46,12 @@ stories:
     - intent: consulta_mecanica
     - action: action_responder_consulta_mecanica
 
-- story: consultar_cita
+  - story: consultar_cita
   steps:
-    - intent: consultar_cita
+    - intent: consultar_cita_activa
     - action: action_consultar_cita
 
-- story: mostrar_historial
+  - story: mostrar_historial
   steps:
-    - intent: mostrar_historial
+    - intent: consultar_historial_citas
     - action: action_mostrar_historial

--- a/domain.yml
+++ b/domain.yml
@@ -5,9 +5,9 @@ intents:
   - solicitar_cita
   - cancelar_cita
   - reprogramar_cita
-  - consultar_cita
+  - consultar_cita_activa
   - consultar_servicios
-  - consultar_horarios
+  - consultar_horarios_disponibles
   - confirmar
   - negar
   - seleccionar_servicio
@@ -17,7 +17,7 @@ intents:
   - agradecer
   - despedirse
   - faq_duracion_servicios
-  - mostrar_historial
+  - consultar_historial_citas
 
 entities:
   - servicio


### PR DESCRIPTION
## Summary
- remove deprecated intents from `nlu.yml`
- rename intents in `domain.yml`
- adjust rules and stories for new names
- document new intent in README
- clarify actions to respond to the renamed intents

## Testing
- `pytest -q`
- `pip install -r requirements.txt` *(fails: No matching distribution found for es-core-news-md==3.4.0)*
- `rasa --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68581ba0b86c832fa2e9aed3351d2c77