### PR TITLE
Fix DB persistence for appointments

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,11 @@ De esta forma el frontend se conectará al WebSocket indicado.
 
 Cuando un usuario agenda una cita y la confirma, el bot registra el servicio,
 fecha y hora en la base de datos SQLite `usuarios.db` dentro de la tabla
-`citas`. El número de teléfono enviado por el frontend se usa como identificador
-del usuario, por lo que las citas quedan asociadas a cada cuenta y pueden
-consultarse posteriormente mediante la intención `consultar_cita_activa`.
+`citas`. Desde esta actualización la tabla incluye una columna `estado` que
+indica si la cita está `confirmada` o `cancelada`. El número de teléfono enviado
+por el frontend se usa como identificador del usuario, por lo que las citas
+quedan asociadas a cada cuenta y pueden consultarse posteriormente mediante la
+intención `consultar_cita_activa`.
 
 ## Persistencia del historial de conversaciones
 


### PR DESCRIPTION
## Summary
- persist appointments with a new `estado` column so upcoming appointments are stored in the database
- update cancellation to mark the next confirmed appointment as `cancelada`
- fetch next appointment and history filtering by `estado`
- document new column in README

## Testing
- `pytest -q`
- `rasa --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685867d2078c832f9aeba04eee2e628e