### PR TITLE
Persist phone-based sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ python backend.py
 
 De esta forma el frontend se conectará al WebSocket indicado.
 
+## Identificador de sesión fijo
+
+El frontend utiliza el número de teléfono del usuario como `session_id` cuando se conecta al WebSocket. Esto permite que el historial de conversaciones y las citas queden vinculadas de forma permanente con la cuenta del usuario. El valor se envía mediante el evento `session_request` al iniciar la conexión, por lo que el mismo identificador se reutiliza aunque el usuario cierre y vuelva a abrir el navegador.
+
 ## Persistencia de citas
 
 Cuando un usuario agenda una cita y la confirma, el bot registra el servicio,

--- a/domain.yml
+++ b/domain.yml
@@ -26,7 +26,8 @@ entities:
 
 slots:
   servicio:
-    type: text
+    type: any
+    auto_fill: false
     influence_conversation: true
     mappings:
       - type: from_entity
@@ -34,7 +35,8 @@ slots:
       - type: from_text
         intent: seleccionar_servicio
   fecha:
-    type: text
+    type: any
+    auto_fill: false
     influence_conversation: true
     mappings:
       - type: from_entity
@@ -42,7 +44,8 @@ slots:
       - type: from_text
         intent: informar_fecha
   hora:
-    type: text
+    type: any
+    auto_fill: false
     influence_conversation: true
     mappings:
       - type: from_entity

--- a/frontend/chatbot.html
+++ b/frontend/chatbot.html
@@ -72,7 +72,14 @@
       title: "Asistente de Taller",
       subtitle: "¿En qué puedo ayudarte?",
       embedded: true,
-      showFullScreenButton: true
+      showFullScreenButton: true,
+      onSocketEvent: {
+        connect: () => {
+          if (webchat && webchat.socket) {
+            webchat.socket.emit("session_request", { session_id: telefonoUsuario });
+          }
+        }
+      }
     });
 
     document.getElementById("logout").addEventListener("click", () => {


### PR DESCRIPTION
## Summary
- keep slot values between sessions
- connect webchat using phone number as session ID
- document session id behaviour

## Testing
- `rasa --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68586d825a24832f895df628b4c995ae