### PR TITLE
Fix domain slot configuration

### DIFF
--- a/domain.yml
+++ b/domain.yml
@@ -27,7 +27,6 @@ entities:
 slots:
   servicio:
     type: any
-    auto_fill: false
     influence_conversation: true
     mappings:
       - type: from_entity
@@ -36,7 +35,6 @@ slots:
         intent: seleccionar_servicio
   fecha:
     type: any
-    auto_fill: false
     influence_conversation: true
     mappings:
       - type: from_entity
@@ -45,7 +43,6 @@ slots:
         intent: informar_fecha
   hora:
     type: any
-    auto_fill: false
     influence_conversation: true
     mappings:
       - type: from_entity
@@ -104,4 +101,4 @@ actions:
 
 session_config:
   session_expiration_time: 60
-  carry_over_slots_to_new_session: true 
+  carry_over_slots_to_new_session: true


### PR DESCRIPTION
## Summary
- remove `auto_fill` from `domain.yml` slot definitions
- ensure newline at end of `domain.yml`

## Testing
- `python - <<'EOF'
import yaml
with open('domain.yml') as f:
    yaml.safe_load(f)
print('YAML valid')
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68587dd93a70832fafc43e70ce907582