### PR TITLE
Fix user ID retrieval for appointment lookup

### DIFF
--- a/actions/actions.py
+++ b/actions/actions.py
@@ -259,7 +259,10 @@ class ActionConsultarCita(Action):
         # Utilizar el sender_id persistente como identificador del usuario
         # Este valor coincide con el número de teléfono que el frontend envía
         # como session_id al conectarse con el bot
-        user_id = tracker.sender_id
+        user_id = (
+            tracker.latest_message.get("metadata", {}).get("sender")
+            or tracker.sender_id
+        )
         try:
             with sqlite3.connect(DB_PATH) as conn:
                 cursor = conn.cursor()


### PR DESCRIPTION
## Summary
- ensure `ActionConsultarCita` looks up appointments using the phone number in metadata

## Testing
- `pytest -q`
- `python -m py_compile actions/actions.py`


------
https://chatgpt.com/codex/tasks/task_e_6859ae1626f0832f9fc5a5643639c9c0