### PR TITLE
Fix HTTP response handling in SocketIO channel

### DIFF
--- a/channels.py
+++ b/channels.py
@@ -82,6 +82,11 @@ class SessionSocketIOInput(SocketIOInput):
         async def health(_: Request) -> HTTPResponse:
             return response.json({"status": "ok"})
 
+        @socketio_webhook.route("/", methods=["POST"])
+        async def handle_request(request: Request) -> HTTPResponse:
+            await sio.handle_request(request)
+            return response.text("ok")
+
         @sio.on("connect", namespace=self.namespace)
         async def connect(sid: Text, environ: Dict, auth: Optional[Dict]) -> bool:
             logger.debug(f"User {sid} connected to socketIO endpoint.")

--- a/frontend/chatbot.html
+++ b/frontend/chatbot.html
@@ -175,20 +175,32 @@
     }
 
     // Inyectamos el chat dentro de #webchat y forzamos embedded:true
-    WebChat.default({
-      initPayload: "/saludo",
-      metadata: { sender: telefonoUsuario },
-      customData: { sender: telefonoUsuario },
-      socketUrl: socketUrl,
-      socketPath: "/socket.io/",
-      title: "Asistente de Taller",
-      subtitle: "¿En qué puedo ayudarte?",
-      embedded: true,              // modo “incrustado”
-      showFullScreenButton: false, // desactiva botón de pantalla completa
-      showCloseButton: false,      // desactiva botón de cerrar
-      session_id: telefonoUsuario,
-      sessionId: telefonoUsuario
-    }, document.getElementById("webchat"));
+      WebChat.default({
+        initPayload: "/saludo",
+        metadata: { sender: telefonoUsuario },
+        customData: { sender: telefonoUsuario },
+        socketUrl: socketUrl,
+        socketPath: "/socket.io/",
+        title: "Asistente de Taller",
+        subtitle: "¿En qué puedo ayudarte?",
+        embedded: true,              // modo “incrustado”
+        showFullScreenButton: false, // desactiva botón de pantalla completa
+        showCloseButton: false,      // desactiva botón de cerrar
+        session_id: telefonoUsuario,
+        sessionId: telefonoUsuario
+      }, document.getElementById("webchat"));
+
+      // Emitir session_request explícitamente para asegurar que el
+      // identificador y la metadata lleguen al backend.
+      window.addEventListener("rasa_webchat_ready", () => {
+        const socket = window.WebChat?.defaultInstance?.socket;
+        if (socket) {
+          socket.emit("session_request", {
+            session_id: telefonoUsuario,
+            metadata: { sender: telefonoUsuario }
+          });
+        }
+      });
 
     // Logout
     document.getElementById("logout").addEventListener("click", () => {


### PR DESCRIPTION
## Summary
- ensure socket route returns an HTTP response
- send `session_id` and metadata when webchat is ready

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b4d000a2c832f91a127cdec7c81ae