### PR TITLE
Fix websocket response and config warning

### DIFF
--- a/channels.py
+++ b/channels.py
@@ -84,8 +84,8 @@ class SessionSocketIOInput(SocketIOInput):
 
         @socketio_webhook.route("/", methods=["POST"])
         async def handle_request(request: Request) -> HTTPResponse:
-            await sio.handle_request(request)
-            return response.text("ok")
+            """Forward the request to ``python-socketio`` and return its response."""
+            return await sio.handle_request(request)
 
         @sio.on("connect", namespace=self.namespace)
         async def connect(sid: Text, environ: Dict, auth: Optional[Dict]) -> bool:

--- a/config.yml
+++ b/config.yml
@@ -12,6 +12,7 @@ pipeline:
 - name: EntitySynonymMapper
 - name: ResponseSelector
   epochs: 50
+  constrain_similarities: true
 
 policies:
 - name: RulePolicy


### PR DESCRIPTION
## Summary
- ensure `SocketIOInput` route returns proper HTTP response
- enable similarity constraints for ResponseSelector

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b515f15bc832fb88e2446ebf41064