### PR TITLE
Silence SQLAlchemy warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,21 @@ Se añadió el canal `session_socketio` definido en `channels.py`. Este canal
 obtiene el identificador del usuario desde la cookie de sesión y lo usa como
 `sender_id` al procesar los mensajes. De esta forma, cada persona conserva sus
 citas y conversaciones aunque cambie la conexión WebSocket.
+
+## Advertencia de SQLAlchemy
+
+Al ejecutar el servidor de Rasa es posible que aparezca el mensaje:
+
+```
+MovedIn20Warning: Deprecated API features detected! ...
+```
+
+Para silenciarlo se define la variable de entorno:
+
+```bash
+export SQLALCHEMY_SILENCE_UBER_WARNING=1
+```
+
+El archivo `backend.py` establece este valor por defecto para que la advertencia
+no aparezca al trabajar con la versión 1.4 de SQLAlchemy incluida en
+`requirements.txt`.

--- a/backend.py
+++ b/backend.py
@@ -5,6 +5,11 @@ import sqlite3
 import hashlib
 import os
 
+# Silencia la advertencia "MovedIn20Warning" de SQLAlchemy que puede
+# aparecer al ejecutar Rasa con la versión 1.4.x. Al definir esta
+# variable de entorno, la advertencia no se muestra en consola.
+os.environ.setdefault("SQLALCHEMY_SILENCE_UBER_WARNING", "1")
+
 
 app = Flask(
     __name__,


### PR DESCRIPTION
## Summary
- silence SQLAlchemy deprecation warnings in backend
- document how to hide the warning in README

## Testing
- `pip install rasa==3.6.21` *(fails: different python version required)*

------
https://chatgpt.com/codex/tasks/task_e_685b67084480832f9eec374b15240078