### PR TITLE
Fix Socket.IO GET request handling

### DIFF
--- a/channels.py
+++ b/channels.py
@@ -78,11 +78,11 @@ class SessionSocketIOInput(SocketIOInput):
         )
         self.sio = sio
 
-        @socketio_webhook.route("/", methods=["GET"])
+        @socketio_webhook.route("/health", methods=["GET"])
         async def health(_: Request) -> HTTPResponse:
             return response.json({"status": "ok"})
 
-        @socketio_webhook.route("/", methods=["POST"])
+        @socketio_webhook.route("/", methods=["GET", "POST"])
         async def handle_request(request: Request) -> HTTPResponse:
             """Forward the request to ``python-socketio`` and return its response."""
             result = await sio.handle_request(request)


### PR DESCRIPTION
## Summary
- correct Socket.IO blueprint so GET requests are processed by socketio server
- expose health check at `/health`

## Testing
- `pytest -q`
- `rasa test --no-pytest` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b746adaf4832f8ad7c9ba68006b73