### PR TITLE
Enable SQLite foreign key checks

### DIFF
--- a/actions/actions.py
+++ b/actions/actions.py
@@ -28,6 +28,7 @@ DB_PATH = "usuarios.db"
 def _init_db() -> None:
     """Ensure the appointments table exists with the proper columns."""
     with sqlite3.connect(DB_PATH) as conn:
+        conn.execute("PRAGMA foreign_keys = ON")
         cursor = conn.cursor()
         cursor.execute("""
             CREATE TABLE IF NOT EXISTS citas (
@@ -80,6 +81,7 @@ class ActionAgendarCita(Action):
         )
         try:
             with sqlite3.connect(DB_PATH) as conn:
+                conn.execute("PRAGMA foreign_keys = ON")
                 cursor = conn.cursor()
                 cursor.execute(
                      "INSERT INTO citas (id_usuario, servicio, fecha, hora, estado) VALUES (?, ?, ?, ?, ?)",
@@ -176,6 +178,7 @@ class ActionCancelarCita(Action):
         )
         try:
             with sqlite3.connect(DB_PATH) as conn:
+                conn.execute("PRAGMA foreign_keys = ON")
                 cursor = conn.cursor()
                 cursor.execute(
                     """
@@ -211,6 +214,7 @@ class ActionMostrarHistorial(Action):
         )
         try:
             with sqlite3.connect(DB_PATH) as conn:
+                conn.execute("PRAGMA foreign_keys = ON")
                 cursor = conn.cursor()
                 cursor.execute(
                     """
@@ -262,6 +266,7 @@ class ActionConsultarCita(Action):
         )
         try:
             with sqlite3.connect(DB_PATH) as conn:
+                conn.execute("PRAGMA foreign_keys = ON")
                 cursor = conn.cursor()
                 cursor.execute(
                     """

--- a/backend.py
+++ b/backend.py
@@ -45,6 +45,7 @@ def obtener_historial(id_usuario: str):
 
 def crear_bd():
     with sqlite3.connect(DB_PATH) as conn:
+        conn.execute("PRAGMA foreign_keys = ON")
         cursor = conn.cursor()
         cursor.execute('''
             CREATE TABLE IF NOT EXISTS usuarios (
@@ -59,6 +60,7 @@ def obtener_citas(id_usuario: str):
     """Return all appointments associated with a user."""
     try:
         with sqlite3.connect(DB_PATH) as conn:
+            conn.execute("PRAGMA foreign_keys = ON")
             cursor = conn.cursor()
             cursor.execute(
                 "SELECT servicio, fecha, hora, estado FROM citas WHERE id_usuario = ? ORDER BY fecha ASC, hora ASC",
@@ -103,6 +105,7 @@ def registro():
 
     
     with sqlite3.connect(DB_PATH) as conn:
+        conn.execute("PRAGMA foreign_keys = ON")
         cursor = conn.cursor()
         intentos = 0
         while True:
@@ -117,6 +120,7 @@ def registro():
 
     try:
         with sqlite3.connect(DB_PATH) as conn:
+            conn.execute("PRAGMA foreign_keys = ON")
             cursor = conn.cursor()
             cursor.execute(
                 "INSERT INTO usuarios (id, telefono, contrasena) VALUES (?, ?, ?)",
@@ -134,6 +138,7 @@ def login():
     contrasena = datos.get("contrasena")
 
     with sqlite3.connect(DB_PATH) as conn:
+        conn.execute("PRAGMA foreign_keys = ON")
         cursor = conn.cursor()
         cursor.execute(
             "SELECT * FROM usuarios WHERE telefono = ? AND contrasena = ?",


### PR DESCRIPTION
## Summary
- turn on SQLite foreign key constraints in actions and backend

## Testing
- `python -m py_compile actions/actions.py backend.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cb5dbe764832fad32626a1cf5397f