### PR TITLE
Fix websocket CORS handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,22 @@ python backend.py
 
 De esta forma el frontend se conectará al WebSocket indicado.
 
+Si el navegador no recibe mensajes del bot, asegúrate de que el origen esté
+autorizado en el canal SocketIO. Por defecto `channels.py` permite cualquier
+origen usando la variable de entorno `SOCKET_CORS` (valor `"*"`). Puedes limitar
+los dominios permitidos especificando una lista separada por comas:
+
+```bash
+export SOCKET_CORS="http://localhost:8000"
+```
+
+Luego inicia Rasa con:
+
+```bash
+rasa run -m models --enable-api --cors "*" --credentials credentials.yml
+```
+
+
 ## Identificador de sesión fijo
 
 El frontend utiliza el número de teléfono del usuario como `session_id` cuando se conecta al WebSocket. Esto permite que el historial de conversaciones y las citas queden vinculadas de forma permanente con la cuenta del usuario. El valor se envía mediante el evento `session_request` al iniciar la conexión, por lo que el mismo identificador se reutiliza aunque el usuario cierre y vuelva a abrir el navegador.

--- a/channels.py
+++ b/channels.py
@@ -1,6 +1,7 @@
 from typing import Optional, Text, Dict, Any, Callable, Awaitable
 import json
 import logging
+import os
 from urllib.parse import parse_qs
 
 from sanic.request import Request
@@ -25,7 +26,8 @@ class SessionSocketIOInput(SocketIOInput):
     def blueprint(
         self, on_new_message: Callable[[UserMessage], Awaitable[Any]]
     ) -> Blueprint:
-        sio = AsyncServer(async_mode="sanic", cors_allowed_origins=[])
+        cors_origins = os.environ.get("SOCKET_CORS", "*")
+        sio = AsyncServer(async_mode="sanic", cors_allowed_origins=cors_origins)
         socketio_webhook = SocketBlueprint(
             sio, self.socketio_path, "socketio_webhook", __name__
         )


### PR DESCRIPTION
## Summary
- allow SocketIO channel to configure allowed origins via `SOCKET_CORS`
- document CORS configuration in README

## Testing
- `python -m py_compile channels.py backend.py actions/actions.py`

------
https://chatgpt.com/codex/tasks/task_e_685e0eae939c832fb117085e38e293d7