### PR TITLE
Implement auto webchat connection

### DIFF
--- a/credentials.yml
+++ b/credentials.yml
@@ -9,5 +9,8 @@ channels.SessionSocketIOInput:
   metadata_key: customData
   session_persistence: true
 
+socketio:
+  session_persistence: true
+
 rasa:
   url: "http://localhost:5002/api"

--- a/frontend/chatbot.html
+++ b/frontend/chatbot.html
@@ -124,6 +124,7 @@
     .rw-full-screen-launcher {
       display: none !important;
     }
+    .rw-launcher { display: none !important; }
     .rw-widget-container {
       position: absolute !important;
       top: 0; left: 0;
@@ -167,22 +168,17 @@
   
 
   <script>
-    const id_usuario = "{{ id_usuario }}";
-    const socketUrl  = "{{ socket_url }}";
-
     WebChat.default.init({
-      selector: "#webchat",           // ¡OBLIGATORIO!
-      socketUrl,
-      socketPath: "/webhooks/session_socketio", // coincide con channels.py   
-      sessionId: id_usuario,          // string único por usuario
-      customData: { sender: id_usuario },
-      initPayload: "/saludo",         // tu saludo inicial
-      title: "Asistente de Taller",
-      subtitle: "¿En qué puedo ayudarte?",
+      selector: "#webchat",
+      socketUrl: "{{ socket_url }}",
+      socketPath: "/webhooks/session_socketio",
+      sessionId: "{{ id_usuario }}",
+      customData: { sender: "{{ id_usuario }}" },
+      initPayload: "/saludo",
       embedded: true,
       showFullScreenButton: false,
       showCloseButton: false,
-      params: { storage: "session" }  // persiste en sessionStorage
+      params: { storage: "session" }
     });
 
     // Logout


### PR DESCRIPTION
## Summary
- embed Rasa Webchat with server URL and session id rendered from Flask
- hide the launcher button in the chat widget
- persist SocketIO sessions in credentials
- improve SessionSocketIOInput to read sender from customData

## Testing
- `pytest -q`
- `python -m py_compile backend.py channels.py`


------
https://chatgpt.com/codex/tasks/task_e_685e3965833c832fabe91d29743d85c3