### PR TITLE
Automatiza saludo inicial con ID de sesión

### DIFF
--- a/channels.py
+++ b/channels.py
@@ -94,6 +94,16 @@ class SessionSocketIOInput(SocketIOInput):
                 namespace=self.namespace,
             )
 
+            # Disparar un saludo inicial apenas se confirma la sesión.
+            output_channel = SocketIOOutput(sio, self.bot_message_evt)
+            message = UserMessage(
+                "/saludo",
+                output_channel,
+                sender,
+                input_channel=self.name(),
+            )
+            await on_new_message(message)
+
         @sio.on(self.user_message_evt, namespace=self.namespace)
         async def handle_message(sid: Text, data: Dict) -> None:
             metadata = data.get(self.metadata_key, {})


### PR DESCRIPTION
## Summary
- start a conversation with `/saludo` once the socket session is confirmed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685f052d9754832fa83c3f5b80248a62