### PR TITLE
Add mechanic and scheduling management

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -13,6 +13,11 @@
 </head>
 <body>
     <h1>Panel de Administración</h1>
+    <p>
+        <a href="/admin/mecanicos">Mecánicos</a> |
+        <a href="/admin/asignaciones">Asignaciones</a> |
+        <a href="/admin/nueva_cita">Nueva Cita</a>
+    </p>
 
     <h2>Usuarios</h2>
     <table>
@@ -43,8 +48,10 @@
             <th>ID Cita</th>
             <th>ID Usuario</th>
             <th>Servicio</th>
+            <th>Mecánico</th>
             <th>Fecha</th>
-            <th>Hora</th>
+            <th>Inicio</th>
+            <th>Fin</th>
             <th>Estado</th>
             <th>Acciones</th>
         </tr>
@@ -54,12 +61,14 @@
                 <td>{{ c[0] }}<input type="hidden" name="id_citas" value="{{ c[0] }}" /></td>
                 <td>{{ c[1] }}</td>
                 <td>{{ c[2] }}</td>
-                <td><input type="date" name="fecha" value="{{ c[3] }}" /></td>
-                <td><input type="time" name="hora" value="{{ c[4] }}" /></td>
+                <td>{{ c[3] }}</td>
+                <td><input type="date" name="fecha" value="{{ c[4] }}" /></td>
+                <td><input type="time" name="hora" value="{{ c[5] }}" /></td>
+                <td>{{ c[6] }}</td>
                 <td>
                     <select name="estado">
                         {% for est in ['confirmada','reprogramada','cancelada','completada'] %}
-                        <option value="{{ est }}" {% if c[5]==est %}selected{% endif %}>{{ est }}</option>
+                        <option value="{{ est }}" {% if c[7]==est %}selected{% endif %}>{{ est }}</option>
                         {% endfor %}
                     </select>
                 </td>

--- a/frontend/asignaciones.html
+++ b/frontend/asignaciones.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Asignar Mecánicos</title>
+    <style>
+      body { font-family: Arial; padding:2rem; background:#f2f2f2; }
+      table { border-collapse: collapse; width:100%; margin-top:1rem; }
+      th, td { border:1px solid #ccc; padding:0.5rem; text-align:left; }
+      th { background:#eee; }
+      form.inline { display:inline; }
+    </style>
+</head>
+<body>
+<h1>Asignar Mecánicos a Servicios</h1>
+<form method="post" action="/admin/asignaciones">
+    <select name="servicio_id">
+        {% for s in servicios %}
+        <option value="{{ s[0] }}">{{ s[1] }}</option>
+        {% endfor %}
+    </select>
+    <select name="mecanico_id">
+        {% for m in mecanicos %}
+        <option value="{{ m[0] }}">{{ m[1] }}</option>
+        {% endfor %}
+    </select>
+    <button type="submit">Asignar</button>
+</form>
+<table>
+    <tr>
+        <th>Servicio</th>
+        <th>Mecánicos asignados</th>
+    </tr>
+    {% for a in asignaciones %}
+    <tr>
+        <td>{{ a.servicio }}</td>
+        <td>
+            {% for m in a.mecanicos %}
+                {{ m[1] }}
+                <form method="post" action="/admin/asignaciones/delete" class="inline" onsubmit="return confirm('¿Quitar?');">
+                    <input type="hidden" name="servicio_id" value="{{ a.id_servicio }}">
+                    <input type="hidden" name="mecanico_id" value="{{ m[0] }}">
+                    <button type="submit">Eliminar</button>
+                </form>
+                <br/>
+            {% endfor %}
+        </td>
+    </tr>
+    {% endfor %}
+</table>
+<a href="/admin">Volver</a>
+</body>
+</html>

--- a/frontend/mecanicos.html
+++ b/frontend/mecanicos.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Gestión de Mecánicos</title>
+    <style>
+      body { font-family: Arial; padding:2rem; background:#f2f2f2; }
+      table { border-collapse: collapse; width: 100%; margin-top:1rem; }
+      th, td { border: 1px solid #ccc; padding:0.5rem; text-align:left; }
+      th { background:#eee; }
+    </style>
+</head>
+<body>
+<h1>Gestión de Mecánicos</h1>
+<form method="post" action="/admin/mecanicos">
+    <input type="text" name="nombre" placeholder="Nombre" required>
+    <input type="text" name="especialidad" placeholder="Especialidad" required>
+    <button type="submit">Agregar</button>
+</form>
+<table>
+    <tr>
+        <th>ID</th>
+        <th>Nombre</th>
+        <th>Especialidad</th>
+        <th>Acciones</th>
+    </tr>
+    {% for m in mecanicos %}
+    <tr>
+        <form method="post" action="/admin/mecanicos/update/{{ m[0] }}">
+            <td>{{ m[0] }}</td>
+            <td><input type="text" name="nombre" value="{{ m[1] }}" /></td>
+            <td><input type="text" name="especialidad" value="{{ m[2] }}" /></td>
+            <td>
+                <button type="submit">Guardar</button>
+        </form>
+        <form method="post" action="/admin/mecanicos/delete/{{ m[0] }}" style="display:inline" onsubmit="return confirm('¿Eliminar?');">
+            <button type="submit">Eliminar</button>
+        </form>
+            </td>
+    </tr>
+    {% endfor %}
+</table>
+<a href="/admin">Volver</a>
+</body>
+</html>

--- a/frontend/nueva_cita.html
+++ b/frontend/nueva_cita.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Nueva Cita</title>
+  <style>
+    body { font-family: Arial; padding:2rem; background:#f2f2f2; }
+    label { display:block; margin-top:0.5rem; }
+    select, input { padding:0.4rem; margin-top:0.3rem; }
+  </style>
+</head>
+<body>
+<h1>Registrar Cita</h1>
+<form method="post" action="/admin/nueva_cita">
+  <label>Usuario:
+    <select name="id_usuario">
+      {% for u in usuarios %}
+      <option value="{{ u[0] }}">{{ u[0] }} - {{ u[1] }}</option>
+      {% endfor %}
+    </select>
+  </label>
+  <label>Servicio:
+    <select name="servicio_id" id="servicio">
+      {% for s in servicios %}
+      <option value="{{ s[0] }}" data-duracion="{{ s[2] }}">{{ s[1] }}</option>
+      {% endfor %}
+    </select>
+  </label>
+  <label>Mecánico:
+    <select name="mecanico_id" id="mecanico">
+      {% for m in mecanicos %}
+      <option value="{{ m[0] }}">{{ m[1] }}</option>
+      {% endfor %}
+    </select>
+  </label>
+  <label>Fecha:
+    <input type="date" name="fecha" id="fecha" required>
+  </label>
+  <label>Hora:
+    <select name="hora_inicio" id="hora" required></select>
+  </label>
+  <button type="submit">Guardar</button>
+</form>
+<a href="/admin">Volver</a>
+<script>
+async function loadHoras() {
+  const s = document.getElementById('servicio').value;
+  const m = document.getElementById('mecanico').value;
+  const f = document.getElementById('fecha').value;
+  if(!s || !m || !f) return;
+  const res = await fetch(`/disponibilidad?servicio_id=${s}&mecanico_id=${m}&fecha=${f}`);
+  const horas = await res.json();
+  const sel = document.getElementById('hora');
+  sel.innerHTML = '';
+  horas.forEach(h => {
+    const o = document.createElement('option');
+    o.value = h;
+    o.textContent = h;
+    sel.appendChild(o);
+  });
+}
+['servicio','mecanico','fecha'].forEach(id => {
+  document.getElementById(id).addEventListener('change', loadHoras);
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add mechanic management tables and triggers
- expose admin pages for mechanics and assignments
- add route to create appointments with overlap validation
- show links to new pages in admin panel
- export CSV with mechanic info

## Testing
- `python -m py_compile backend.py`

------
https://chatgpt.com/codex/tasks/task_e_6860c52a8618832f8dcfbde6fc5bf29c