### PR TITLE
Add mechanic management and improved scheduling

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -56,18 +56,121 @@ def crear_bd():
     with sqlite3.connect(DB_PATH) as conn:
         conn.execute("PRAGMA foreign_keys = ON")
         cursor = conn.cursor()
-        cursor.execute('''
+        cursor.execute(
+            """
             CREATE TABLE IF NOT EXISTS usuarios (
                 id_usuario TEXT PRIMARY KEY,
                 telefono INTEGER UNIQUE NOT NULL,
                 contrasena TEXT NOT NULL,
                 es_admin INTEGER NOT NULL DEFAULT 0
             )
-        ''')
+            """
+        )
+
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS servicios (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                nombre TEXT UNIQUE NOT NULL,
+                duracion_min INTEGER NOT NULL
+            )
+            """
+        )
+
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS mecanicos (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                nombre TEXT NOT NULL,
+                especialidad TEXT
+            )
+            """
+        )
+
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS servicio_mecanico (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                id_servicio INTEGER NOT NULL,
+                id_mecanico INTEGER NOT NULL,
+                FOREIGN KEY(id_servicio) REFERENCES servicios(id) ON DELETE CASCADE,
+                FOREIGN KEY(id_mecanico) REFERENCES mecanicos(id) ON DELETE CASCADE,
+                UNIQUE(id_servicio, id_mecanico)
+            )
+            """
+        )
+
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS citas (
+                id TEXT PRIMARY KEY,
+                id_usuario TEXT NOT NULL,
+                id_servicio INTEGER NOT NULL,
+                id_mecanico INTEGER NOT NULL,
+                fecha TEXT NOT NULL,
+                hora_inicio TEXT NOT NULL,
+                hora_fin TEXT NOT NULL,
+                estado TEXT NOT NULL CHECK(
+                    estado IN ('confirmada','reprogramada','cancelada','completada')
+                ),
+                FOREIGN KEY(id_usuario) REFERENCES usuarios(id_usuario) ON DELETE CASCADE,
+                FOREIGN KEY(id_servicio) REFERENCES servicios(id) ON DELETE CASCADE,
+                FOREIGN KEY(id_mecanico) REFERENCES mecanicos(id) ON DELETE CASCADE
+            )
+            """
+        )
+
+        cursor.execute(
+            """
+            CREATE TRIGGER IF NOT EXISTS trg_no_overlap_insert
+            BEFORE INSERT ON citas
+            BEGIN
+                SELECT CASE WHEN EXISTS (
+                    SELECT 1 FROM citas
+                    WHERE id_mecanico = NEW.id_mecanico
+                      AND fecha = NEW.fecha
+                      AND NOT (
+                        time(hora_fin, '+10 minutes') <= NEW.hora_inicio OR
+                        time(NEW.hora_fin, '+10 minutes') <= hora_inicio
+                    )
+                ) THEN RAISE(ABORT, 'solapamiento') END;
+            END;
+            """
+        )
+
+        cursor.execute(
+            """
+            CREATE TRIGGER IF NOT EXISTS trg_no_overlap_update
+            BEFORE UPDATE ON citas
+            BEGIN
+                SELECT CASE WHEN EXISTS (
+                    SELECT 1 FROM citas
+                    WHERE id != NEW.id
+                      AND id_mecanico = NEW.id_mecanico
+                      AND fecha = NEW.fecha
+                      AND NOT (
+                        time(hora_fin, '+10 minutes') <= NEW.hora_inicio OR
+                        time(NEW.hora_fin, '+10 minutes') <= hora_inicio
+                    )
+                ) THEN RAISE(ABORT, 'solapamiento') END;
+            END;
+            """
+        )
+
         if inicial:
             cursor.execute(
                 "INSERT INTO usuarios (id_usuario, telefono, contrasena, es_admin) VALUES (?,?,?,1)",
                 ("admin", 99999999, hash_contrasena("admin123"))
+            )
+            cursor.executemany(
+                "INSERT INTO servicios (nombre, duracion_min) VALUES (?, ?)",
+                [
+                    ("Cambio de aceite", 30),
+                    ("Revisión general", 60),
+                    ("Alineación", 45),
+                    ("Balanceo", 30),
+                    ("Mantenimiento preventivo", 120),
+                ],
             )
         conn.commit()
         
@@ -79,7 +182,14 @@ def obtener_citas(id_usuario: str):
             conn.execute("PRAGMA foreign_keys = ON")
             cursor = conn.cursor()
             cursor.execute(
-                "SELECT id_citas, servicio, fecha, hora, estado FROM citas WHERE id_usuario = ? ORDER BY fecha ASC, hora ASC",
+                """
+                SELECT c.id, s.nombre, m.nombre, c.fecha, c.hora_inicio, c.hora_fin, c.estado
+                FROM citas c
+                JOIN servicios s ON c.id_servicio = s.id
+                JOIN mecanicos m ON c.id_mecanico = m.id
+                WHERE c.id_usuario = ?
+                ORDER BY c.fecha ASC, c.hora_inicio ASC
+                """,
                 (id_usuario,),
             )
             rows = cursor.fetchall()
@@ -89,11 +199,13 @@ def obtener_citas(id_usuario: str):
         {
             "id_citas": cid,
             "servicio": s,
+            "mecanico": m,
             "fecha": f,
             "hora": h,
+            "hora_fin": hf,
             "estado": e,
         }
-        for cid, s, f, h, e in rows
+        for cid, s, m, f, h, hf, e in rows
     ]
 
 def hash_contrasena(password: str) -> str:
@@ -230,18 +342,23 @@ def admin_view():
     fecha = request.args.get("fecha")
     hora = request.args.get("hora")
 
-    query = "SELECT id_citas, id_usuario, servicio, fecha, hora, estado FROM citas WHERE 1=1"
+    query = (
+        "SELECT c.id, c.id_usuario, s.nombre, m.nombre, c.fecha, c.hora_inicio, c.hora_fin, c.estado "
+        "FROM citas c "
+        "JOIN servicios s ON c.id_servicio = s.id "
+        "JOIN mecanicos m ON c.id_mecanico = m.id WHERE 1=1"
+    )
     params = []
     if servicio:
-        query += " AND servicio LIKE ?"
+        query += " AND s.nombre LIKE ?"
         params.append(f"%{servicio}%")
     if fecha:
         query += " AND fecha = ?"
         params.append(fecha)
     if hora:
-        query += " AND hora = ?"
+        query += " AND c.hora_inicio = ?"
         params.append(hora)
-    query += " ORDER BY fecha ASC, hora ASC"
+    query += " ORDER BY c.fecha ASC, c.hora_inicio ASC"
 
     with sqlite3.connect(DB_PATH) as conn:
         conn.execute("PRAGMA foreign_keys = ON")
@@ -250,9 +367,31 @@ def admin_view():
             "SELECT id_usuario, telefono, es_admin FROM usuarios"
         ).fetchall()
         citas = cursor.execute(query, params).fetchall()
+        mecanicos = cursor.execute(
+            "SELECT id, nombre, especialidad FROM mecanicos"
+        ).fetchall()
+        servicios = cursor.execute(
+            "SELECT id, nombre FROM servicios"
+        ).fetchall()
+        asignaciones = cursor.execute(
+            """
+            SELECT s.id, m.id
+            FROM servicio_mecanico sm
+            JOIN servicios s ON sm.id_servicio = s.id
+            JOIN mecanicos m ON sm.id_mecanico = m.id
+            """
+        ).fetchall()
 
     filtros = {"servicio": servicio or "", "fecha": fecha or "", "hora": hora or ""}
-    return render_template("admin.html", usuarios=usuarios, citas=citas, filtros=filtros)
+    return render_template(
+        "admin.html",
+        usuarios=usuarios,
+        citas=citas,
+        mecanicos=mecanicos,
+        servicios=servicios,
+        asignaciones=asignaciones,
+        filtros=filtros,
+    )
 
 
 @app.route("/admin/update_cita", methods=["POST"])
@@ -269,9 +408,18 @@ def update_cita():
     with sqlite3.connect(DB_PATH) as conn:
         conn.execute("PRAGMA foreign_keys = ON")
         cursor = conn.cursor()
+        dur = cursor.execute(
+            "SELECT s.duracion_min FROM citas c JOIN servicios s ON c.id_servicio = s.id WHERE c.id = ?",
+            (id_cita,),
+        ).fetchone()
+        duracion = dur[0] if dur else 0
+        from datetime import datetime, timedelta
+        hora_fin = (
+            datetime.strptime(hora, "%H:%M") + timedelta(minutes=duracion)
+        ).strftime("%H:%M")
         cursor.execute(
-            "UPDATE citas SET fecha = ?, hora = ?, estado = ? WHERE id_citas = ?",
-            (fecha, hora, estado, id_cita),
+            "UPDATE citas SET fecha = ?, hora_inicio = ?, hora_fin = ?, estado = ? WHERE id = ?",
+            (fecha, hora, hora_fin, estado, id_cita),
         )
         conn.commit()
     return redirect(url_for("admin_view"))
@@ -286,7 +434,7 @@ def delete_cita():
     with sqlite3.connect(DB_PATH) as conn:
         conn.execute("PRAGMA foreign_keys = ON")
         cursor = conn.cursor()
-        cursor.execute("DELETE FROM citas WHERE id_citas = ?", (id_cita,))
+        cursor.execute("DELETE FROM citas WHERE id = ?", (id_cita,))
         conn.commit()
     return redirect(url_for("admin_view"))
 
@@ -300,18 +448,166 @@ def export_csv():
         conn.execute("PRAGMA foreign_keys = ON")
         cursor = conn.cursor()
         rows = cursor.execute(
-            "SELECT id_citas, id_usuario, servicio, fecha, hora, estado FROM citas"
+            """
+            SELECT c.id, c.id_usuario, s.nombre, m.nombre, c.fecha, c.hora_inicio, c.hora_fin, c.estado
+            FROM citas c
+            JOIN servicios s ON c.id_servicio = s.id
+            JOIN mecanicos m ON c.id_mecanico = m.id
+            """
         ).fetchall()
     import csv
     from io import StringIO
     si = StringIO()
     writer = csv.writer(si)
-    writer.writerow(["id_citas", "id_usuario", "servicio", "fecha", "hora", "estado"])
+    writer.writerow([
+        "id_citas",
+        "id_usuario",
+        "servicio",
+        "mecanico",
+        "fecha",
+        "hora_inicio",
+        "hora_fin",
+        "estado",
+    ])
     writer.writerows(rows)
     output = make_response(si.getvalue())
     output.headers["Content-Disposition"] = "attachment; filename=citas.csv"
     output.headers["Content-type"] = "text/csv"
     return output
+
+
+@app.route("/admin/add_mecanico", methods=["POST"])
+def add_mecanico():
+    if not session.get("es_admin"):
+        return redirect(url_for("index"))
+    nombre = request.form.get("nombre")
+    especialidad = request.form.get("especialidad")
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute("PRAGMA foreign_keys = ON")
+        cursor = conn.cursor()
+        cursor.execute(
+            "INSERT INTO mecanicos (nombre, especialidad) VALUES (?, ?)",
+            (nombre, especialidad),
+        )
+        conn.commit()
+    return redirect(url_for("admin_view"))
+
+
+@app.route("/admin/update_mecanico", methods=["POST"])
+def update_mecanico():
+    if not session.get("es_admin"):
+        return redirect(url_for("index"))
+    mid = request.form.get("id")
+    nombre = request.form.get("nombre")
+    especialidad = request.form.get("especialidad")
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute("PRAGMA foreign_keys = ON")
+        cursor = conn.cursor()
+        cursor.execute(
+            "UPDATE mecanicos SET nombre = ?, especialidad = ? WHERE id = ?",
+            (nombre, especialidad, mid),
+        )
+        conn.commit()
+    return redirect(url_for("admin_view"))
+
+
+@app.route("/admin/delete_mecanico", methods=["POST"])
+def delete_mecanico():
+    if not session.get("es_admin"):
+        return redirect(url_for("index"))
+    mid = request.form.get("id")
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute("PRAGMA foreign_keys = ON")
+        cursor = conn.cursor()
+        cursor.execute("DELETE FROM mecanicos WHERE id = ?", (mid,))
+        conn.commit()
+    return redirect(url_for("admin_view"))
+
+
+@app.route("/admin/asignar_servicios", methods=["POST"])
+def asignar_servicios():
+    if not session.get("es_admin"):
+        return redirect(url_for("index"))
+    servicio_id = request.form.get("servicio_id")
+    mecanicos_sel = request.form.getlist("mecanicos")
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute("PRAGMA foreign_keys = ON")
+        cursor = conn.cursor()
+        cursor.execute(
+            "DELETE FROM servicio_mecanico WHERE id_servicio = ?",
+            (servicio_id,),
+        )
+        for mid in mecanicos_sel:
+            cursor.execute(
+                "INSERT INTO servicio_mecanico (id_servicio, id_mecanico) VALUES (?, ?)",
+                (servicio_id, mid),
+            )
+        conn.commit()
+    return redirect(url_for("admin_view"))
+
+
+def calcular_disponibilidad(citas, duracion):
+    from datetime import datetime, timedelta
+    start = datetime.strptime("08:00", "%H:%M")
+    end = datetime.strptime("18:00", "%H:%M")
+    delta = timedelta(minutes=duracion)
+    buffer = timedelta(minutes=10)
+    intervals = [
+        (datetime.strptime(i, "%H:%M"), datetime.strptime(f, "%H:%M"))
+        for i, f in citas
+    ]
+    intervals.sort()
+    horarios = []
+    actual = start
+    for ini, fin in intervals:
+        while actual + delta <= ini - buffer:
+            horarios.append(actual.strftime("%H:%M"))
+            actual += timedelta(minutes=30)
+        if actual < fin + buffer:
+            actual = fin + buffer
+    while actual + delta <= end:
+        horarios.append(actual.strftime("%H:%M"))
+        actual += timedelta(minutes=30)
+    return horarios
+
+
+@app.route("/admin/disponibilidad")
+def disponibilidad():
+    if not session.get("es_admin"):
+        return jsonify({})
+    servicio_id = request.args.get("servicio_id")
+    fecha = request.args.get("fecha")
+    if not servicio_id or not fecha:
+        return jsonify({})
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute("PRAGMA foreign_keys = ON")
+        cursor = conn.cursor()
+        dur = cursor.execute(
+            "SELECT duracion_min FROM servicios WHERE id = ?",
+            (servicio_id,),
+        ).fetchone()
+        if not dur:
+            return jsonify({})
+        duracion = dur[0]
+        mecanicos = cursor.execute(
+            """
+            SELECT m.id, m.nombre FROM mecanicos m
+            JOIN servicio_mecanico sm ON m.id = sm.id_mecanico
+            WHERE sm.id_servicio = ?
+            """,
+            (servicio_id,),
+        ).fetchall()
+        resultado = {}
+        for mid, nombre in mecanicos:
+            citas = cursor.execute(
+                "SELECT hora_inicio, hora_fin FROM citas WHERE id_mecanico = ? AND fecha = ? ORDER BY hora_inicio",
+                (mid, fecha),
+            ).fetchall()
+            resultado[mid] = {
+                "nombre": nombre,
+                "horarios": calcular_disponibilidad(citas, duracion),
+            }
+    return jsonify(resultado)
 
 if __name__ == "__main__":
     crear_bd()

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -74,5 +74,64 @@
         </tr>
         {% endfor %}
     </table>
+
+    <h2>Mecánicos</h2>
+    <form method="post" action="/admin/add_mecanico">
+        <input type="text" name="nombre" placeholder="Nombre" required />
+        <input type="text" name="especialidad" placeholder="Especialidad" />
+        <button type="submit">Agregar</button>
+    </form>
+    <table>
+        <tr>
+            <th>ID</th>
+            <th>Nombre</th>
+            <th>Especialidad</th>
+            <th>Acciones</th>
+        </tr>
+        {% for m in mecanicos %}
+        <tr>
+            <form method="post" action="/admin/update_mecanico">
+                <td>{{ m[0] }}<input type="hidden" name="id" value="{{ m[0] }}" /></td>
+                <td><input type="text" name="nombre" value="{{ m[1] }}" /></td>
+                <td><input type="text" name="especialidad" value="{{ m[2] or '' }}" /></td>
+                <td>
+                    <button type="submit">Guardar</button>
+            </form>
+            <form method="post" action="/admin/delete_mecanico" style="display:inline" onsubmit="return confirm('¿Eliminar mecánico?');">
+                <input type="hidden" name="id" value="{{ m[0] }}" />
+                <button type="submit">Eliminar</button>
+            </form>
+                </td>
+        </tr>
+        {% endfor %}
+    </table>
+
+    <h2>Asignación de Mecánicos</h2>
+    <form method="post" action="/admin/asignar_servicios">
+        <select name="servicio_id">
+            {% for s in servicios %}
+            <option value="{{ s[0] }}">{{ s[1] }}</option>
+            {% endfor %}
+        </select>
+        <div>
+            {% for m in mecanicos %}
+            <label>
+                <input type="checkbox" name="mecanicos" value="{{ m[0] }}" /> {{ m[1] }}
+            </label>
+            {% endfor %}
+        </div>
+        <button type="submit">Guardar</button>
+    </form>
+
+    <h3>Asignaciones actuales</h3>
+    <table>
+        <tr><th>Servicio</th><th>Mecánico</th></tr>
+        {% for sid, mid in asignaciones %}
+        <tr>
+            <td>{{ servicios|selectattr('0', 'equalto', sid)|map(attribute=1)|list|first }}</td>
+            <td>{{ mecanicos|selectattr('0', 'equalto', mid)|map(attribute=1)|list|first }}</td>
+        </tr>
+        {% endfor %}
+    </table>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- create new schema with services, mechanics, and appointment triggers
- extend admin panel with mechanic management and service assignments
- add endpoints to handle mechanic CRUD and scheduling
- expose availability calculation per mechanic

## Testing
- `python -m py_compile backend.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860cc096bbc832f804ad3ecc50cfef9