### PR TITLE
Add admin panel with protected routes

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<title>Panel de Administración</title>
+<style>
+  body {font-family: Arial, sans-serif; padding: 1rem;}
+  table {border-collapse: collapse; width: 100%; margin-bottom: 2rem;}
+  th, td {border: 1px solid #ccc; padding: 0.5rem; text-align: left;}
+  th {background-color: #f0f0f0;}
+</style>
+</head>
+<body>
+  <h1>Panel de Administración</h1>
+  <a href="/logout">Cerrar sesión</a>
+
+  <h2>Usuarios</h2>
+  <table>
+    <tr><th>ID</th><th>Teléfono</th><th>Es admin</th></tr>
+    {% for u in usuarios %}
+    <tr>
+      <td>{{ u['id_usuario'] }}</td>
+      <td>{{ u['telefono'] }}</td>
+      <td>{{ u['es_admin'] }}</td>
+    </tr>
+    {% endfor %}
+  </table>
+
+  <h2>Citas</h2>
+  <table>
+    <tr><th>ID</th><th>Usuario</th><th>Servicio</th><th>Fecha</th><th>Hora</th><th>Estado</th></tr>
+    {% for c in citas %}
+    <tr>
+      <td>{{ c['id_citas'] }}</td>
+      <td>{{ c['id_usuario'] }}</td>
+      <td>{{ c['servicio'] }}</td>
+      <td>{{ c['fecha'] }}</td>
+      <td>{{ c['hora'] }}</td>
+      <td>{{ c['estado'] }}</td>
+    </tr>
+    {% endfor %}
+  </table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `es_admin` column and create a default admin user when initializing the DB
- store admin flag in session on login
- protect new `/admin` route that lists all rows from both tables
- show complete DB contents in new `admin.html`
- logout clears the admin flag

## Testing
- `python -m py_compile backend.py actions/actions.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861850e9974832f9e20389b52ea42c3