### PR TITLE
Enable admin appointment editing

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -226,6 +226,45 @@ def admin_panel():
 
     return render_template("admin.html", usuarios=usuarios, citas=citas)
 
+@app.route("/editar_cita/<id_cita>", methods=["GET", "POST"])
+def editar_cita(id_cita):
+    """Permite editar una cita existente."""
+    if not session.get("es_admin"):
+        return redirect(url_for("index"))
+
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.row_factory = sqlite3.Row
+        cursor = conn.cursor()
+
+        if request.method == "POST":
+            cursor.execute(
+                """
+                UPDATE citas
+                SET id_usuario = ?, servicio = ?, fecha = ?, hora = ?, estado = ?
+                WHERE id_citas = ?
+                """,
+                (
+                    request.form.get("id_usuario"),
+                    request.form.get("servicio"),
+                    request.form.get("fecha"),
+                    request.form.get("hora"),
+                    request.form.get("estado"),
+                    id_cita,
+                ),
+            )
+            conn.commit()
+            return redirect(url_for("admin_panel"))
+
+        cursor.execute(
+            "SELECT id_citas, id_usuario, servicio, fecha, hora, estado FROM citas WHERE id_citas = ?",
+            (id_cita,),
+        )
+        cita = cursor.fetchone()
+        if not cita:
+            return redirect(url_for("admin_panel"))
+
+    return render_template("editar_cita.html", cita=cita)
+
 @app.route("/logout")
 def logout():
     session.pop("id_usuario", None)

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -28,7 +28,7 @@
 
   <h2>Citas</h2>
   <table>
-    <tr><th>ID</th><th>Usuario</th><th>Servicio</th><th>Fecha</th><th>Hora</th><th>Estado</th></tr>
+    <tr><th>ID</th><th>Usuario</th><th>Servicio</th><th>Fecha</th><th>Hora</th><th>Estado</th><th>Acciones</th></tr>
     {% for c in citas %}
     <tr>
       <td>{{ c['id_citas'] }}</td>
@@ -37,6 +37,7 @@
       <td>{{ c['fecha'] }}</td>
       <td>{{ c['hora'] }}</td>
       <td>{{ c['estado'] }}</td>
+      <td><a href="/editar_cita/{{ c['id_citas'] }}">Editar</a></td>
     </tr>
     {% endfor %}
   </table>

--- a/frontend/editar_cita.html
+++ b/frontend/editar_cita.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<title>Editar Cita</title>
+<style>
+  body {font-family: Arial, sans-serif; padding: 1rem;}
+  form {max-width: 400px;}
+  label {display: block; margin-top: 0.5rem;}
+  input, select {width: 100%; padding: 0.5rem; margin-top: 0.25rem;}
+  button {margin-top: 1rem; padding: 0.5rem 1rem;}
+</style>
+</head>
+<body>
+  <h1>Editar Cita</h1>
+  <form method="post">
+    <input type="hidden" name="id_citas" value="{{ cita['id_citas'] }}">
+
+    <label>ID Usuario
+      <input type="text" name="id_usuario" value="{{ cita['id_usuario'] }}" required>
+    </label>
+    <label>Servicio
+      <input type="text" name="servicio" value="{{ cita['servicio'] }}" required>
+    </label>
+    <label>Fecha
+      <input type="text" name="fecha" value="{{ cita['fecha'] }}" required>
+    </label>
+    <label>Hora
+      <input type="text" name="hora" value="{{ cita['hora'] }}" required>
+    </label>
+    <label>Estado
+      <select name="estado">
+        {% for estado in ['confirmada', 'reprogramada', 'cancelada', 'completada'] %}
+        <option value="{{ estado }}" {% if cita['estado']==estado %}selected{% endif %}>{{ estado }}</option>
+        {% endfor %}
+      </select>
+    </label>
+
+    <button type="submit">Guardar</button>
+  </form>
+  <p><a href="/admin">Volver al panel</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add link to edit appointments in the admin panel
- implement view and POST handler to edit appointment information
- new template for editing a single appointment

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68618b6c0fb8832fbf6081042fb1bc7a