### PR TITLE
Allow editing appointments from admin panel

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -226,6 +226,28 @@ def admin_panel():
 
     return render_template("admin.html", usuarios=usuarios, citas=citas)
 
+@app.route("/admin/actualizar_cita/<id_cita>", methods=["POST"])
+def actualizar_cita(id_cita):
+    """Permite modificar una cita desde el panel de administración."""
+    if not session.get("es_admin"):
+        return redirect(url_for("index"))
+
+    servicio = request.form.get("servicio")
+    fecha = request.form.get("fecha")
+    hora = request.form.get("hora")
+    estado = request.form.get("estado")
+
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute("PRAGMA foreign_keys = ON")
+        cursor = conn.cursor()
+        cursor.execute(
+            "UPDATE citas SET servicio = ?, fecha = ?, hora = ?, estado = ? WHERE id_citas = ?",
+            (servicio, fecha, hora, estado, id_cita),
+        )
+        conn.commit()
+
+    return redirect(url_for("admin_panel"))
+
 @app.route("/logout")
 def logout():
     session.pop("id_usuario", None)

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -28,16 +28,34 @@
 
   <h2>Citas</h2>
   <table>
-    <tr><th>ID</th><th>Usuario</th><th>Servicio</th><th>Fecha</th><th>Hora</th><th>Estado</th></tr>
-    {% for c in citas %}
     <tr>
-      <td>{{ c['id_citas'] }}</td>
-      <td>{{ c['id_usuario'] }}</td>
-      <td>{{ c['servicio'] }}</td>
-      <td>{{ c['fecha'] }}</td>
-      <td>{{ c['hora'] }}</td>
-      <td>{{ c['estado'] }}</td>
+      <th>ID</th>
+      <th>Usuario</th>
+      <th>Servicio</th>
+      <th>Fecha</th>
+      <th>Hora</th>
+      <th>Estado</th>
+      <th></th>
     </tr>
+    {% for c in citas %}
+    <form action="/admin/actualizar_cita/{{ c['id_citas'] }}" method="post" style="display: contents;">
+      <tr>
+        <td>{{ c['id_citas'] }}</td>
+        <td>{{ c['id_usuario'] }}</td>
+        <td><input name="servicio" value="{{ c['servicio'] }}"></td>
+        <td><input type="date" name="fecha" value="{{ c['fecha'] }}"></td>
+        <td><input type="time" name="hora" value="{{ c['hora'] }}"></td>
+        <td>
+          <select name="estado">
+            <option value="confirmada" {% if c['estado']=='confirmada' %}selected{% endif %}>confirmada</option>
+            <option value="reprogramada" {% if c['estado']=='reprogramada' %}selected{% endif %}>reprogramada</option>
+            <option value="cancelada" {% if c['estado']=='cancelada' %}selected{% endif %}>cancelada</option>
+            <option value="completada" {% if c['estado']=='completada' %}selected{% endif %}>completada</option>
+          </select>
+        </td>
+        <td><button type="submit">Guardar</button></td>
+      </tr>
+    </form>
     {% endfor %}
   </table>
 </body>


### PR DESCRIPTION
## Summary
- make appointment fields editable from admin panel
- add `/admin/actualizar_cita/<id_cita>` endpoint to save changes

## Testing
- `python -m py_compile backend.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68618d10bef8832fbbe3f6eb4f90c0e3