### PR TITLE
Enable mechanic CRUD in admin panel

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -267,6 +267,65 @@ def actualizar_cita(id_cita):
 
     return redirect(url_for("admin_panel"))
 
+@app.route("/admin/agregar_mecanico", methods=["POST"])
+def agregar_mecanico():
+    """Agregar un nuevo mecánico desde el panel de administración."""
+    if not session.get("es_admin"):
+        return redirect(url_for("index"))
+
+    nombre = request.form.get("nombre")
+    telefono = request.form.get("telefono")
+    if not nombre:
+        return redirect(url_for("admin_panel"))
+
+    id_mecanico = generar_id_aleatorio()
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute("PRAGMA foreign_keys = ON")
+        cursor = conn.cursor()
+        cursor.execute(
+            "INSERT INTO mecanicos (id_mecanico, nombre, telefono) VALUES (?, ?, ?)",
+            (id_mecanico, nombre, telefono),
+        )
+        conn.commit()
+
+    return redirect(url_for("admin_panel"))
+
+@app.route("/admin/actualizar_mecanico/<id_mecanico>", methods=["POST"])
+def actualizar_mecanico(id_mecanico):
+    """Editar los datos de un mecánico."""
+    if not session.get("es_admin"):
+        return redirect(url_for("index"))
+
+    nombre = request.form.get("nombre")
+    telefono = request.form.get("telefono")
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute("PRAGMA foreign_keys = ON")
+        cursor = conn.cursor()
+        cursor.execute(
+            "UPDATE mecanicos SET nombre = ?, telefono = ? WHERE id_mecanico = ?",
+            (nombre, telefono, id_mecanico),
+        )
+        conn.commit()
+
+    return redirect(url_for("admin_panel"))
+
+@app.route("/admin/eliminar_mecanico/<id_mecanico>", methods=["POST"])
+def eliminar_mecanico(id_mecanico):
+    """Eliminar un mecánico de la base de datos."""
+    if not session.get("es_admin"):
+        return redirect(url_for("index"))
+
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute("PRAGMA foreign_keys = ON")
+        cursor = conn.cursor()
+        cursor.execute(
+            "DELETE FROM mecanicos WHERE id_mecanico = ?",
+            (id_mecanico,),
+        )
+        conn.commit()
+
+    return redirect(url_for("admin_panel"))
+
 @app.route("/logout")
 def logout():
     session.pop("id_usuario", None)

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -61,14 +61,36 @@
 
   <h2>Mecánicos</h2>
   <table>
-    <tr><th>ID</th><th>Nombre</th><th>Teléfono</th></tr>
+    <tr>
+      <th>ID</th>
+      <th>Nombre</th>
+      <th>Teléfono</th>
+      <th></th>
+      <th></th>
+    </tr>
     {% for m in mecanicos %}
     <tr>
-      <td>{{ m['id_mecanico'] }}</td>
-      <td>{{ m['nombre'] }}</td>
-      <td>{{ m['telefono'] }}</td>
+      <form action="/admin/actualizar_mecanico/{{ m['id_mecanico'] }}" method="post" style="display: contents;">
+        <td>{{ m['id_mecanico'] }}</td>
+        <td><input name="nombre" value="{{ m['nombre'] }}"></td>
+        <td><input name="telefono" value="{{ m['telefono'] }}"></td>
+        <td><button type="submit">Guardar</button></td>
+      </form>
+      <td>
+        <form action="/admin/eliminar_mecanico/{{ m['id_mecanico'] }}" method="post" style="display: inline;">
+          <button type="submit">Eliminar</button>
+        </form>
+      </td>
     </tr>
     {% endfor %}
+    <tr>
+      <form action="/admin/agregar_mecanico" method="post" style="display: contents;">
+        <td>Nuevo</td>
+        <td><input name="nombre" placeholder="Nombre"></td>
+        <td><input name="telefono" placeholder="Teléfono"></td>
+        <td colspan="2"><button type="submit">Agregar</button></td>
+      </form>
+    </tr>
   </table>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add backend routes for mechanics CRUD
- support editing, deleting and adding mechanics in `admin.html`
- clean up newline at end of `backend.py`

## Testing
- `pytest -q`
- `python -m py_compile backend.py actions/actions.py`

------
https://chatgpt.com/codex/tasks/task_e_68619509ce38832fbba63a8ecfb29c69