### PR TITLE
Add inline edit for mechanics

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -107,34 +107,37 @@
     </tr>
   </table>
   <script>
-    document.querySelectorAll('.mecanico-form .edit-btn').forEach(btn => {
-      btn.addEventListener('click', async () => {
-        const form = btn.closest('.mecanico-form');
-        const inputs = form.querySelectorAll('input');
-        const editing = btn.getAttribute('data-editing') === 'true';
-        if (!editing) {
-          inputs.forEach(i => i.disabled = false);
-          btn.setAttribute('data-editing', 'true');
-          btn.textContent = 'Guardar';
-          btn.classList.add('save');
-        } else {
-          const params = new URLSearchParams();
-          inputs.forEach(i => params.append(i.name, i.value));
-          const id = form.dataset.id;
-          const res = await fetch(`/admin/actualizar_mecanico/${id}`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-            body: params.toString()
-          });
-          if (res.ok) {
-            inputs.forEach(i => i.disabled = true);
-            btn.setAttribute('data-editing', 'false');
-            btn.textContent = 'Editar';
-            btn.classList.remove('save');
+    document.addEventListener('DOMContentLoaded', () => {
+      document.querySelectorAll('.mecanico-form .edit-btn').forEach(btn => {
+        btn.addEventListener('click', async (e) => {
+          e.preventDefault();
+          const form = btn.closest('.mecanico-form');
+          const inputs = form.querySelectorAll('input');
+          const editing = btn.getAttribute('data-editing') === 'true';
+          if (!editing) {
+            inputs.forEach(i => i.disabled = false);
+            btn.setAttribute('data-editing', 'true');
+            btn.textContent = 'Guardar';
+            btn.classList.add('save');
           } else {
-            alert('Error al guardar');
+            const params = new URLSearchParams();
+            inputs.forEach(i => params.append(i.name, i.value));
+            const id = form.dataset.id;
+            const res = await fetch(`/admin/actualizar_mecanico/${id}`, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+              body: params.toString()
+            });
+            if (res.ok) {
+              inputs.forEach(i => i.disabled = true);
+              btn.setAttribute('data-editing', 'false');
+              btn.textContent = 'Editar';
+              btn.classList.remove('save');
+            } else {
+              alert('Error al guardar');
+            }
           }
-        }
+        });
       });
     });
   </script>


### PR DESCRIPTION
## Summary
- add modern styles and responsive table for admin panel
- enable inline edit/save for mechanics via JS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686199b8922c832f9539ae5370ec647e