### PR TITLE
Add phone dropdown for new admin appointment

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -92,7 +92,14 @@
       {% endfor %}
       <tr>
         <td>Nuevo</td>
-        <td><input type="text" id="new-usuario" placeholder="Usuario"></td>
+        <td>
+          <select id="new-usuario">
+            <option value="" selected disabled>Seleccione teléfono</option>
+            {% for u in usuarios %}
+            <option value="{{ u.id_usuario }}">{{ u.telefono }}</option>
+            {% endfor %}
+          </select>
+        </td>
         <td></td>
         <td><input type="text" id="new-servicio" placeholder="Servicio"></td>
         <td><input type="date" id="new-fecha"></td>


### PR DESCRIPTION
## Summary
- add a select element listing user phone numbers when creating a new appointment
- keep the existing appointment rows read‑only for the `id_usuario` field

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861a7e063a4832f819535c4686656ae