### PR TITLE
Add appointment availability table

### DIFF
--- a/domain.yml
+++ b/domain.yml
@@ -64,7 +64,7 @@ responses:
   utter_ask_fecha:
     - text: "¿Para qué fecha deseas agendar la cita? (Ejemplo: 2025-06-15)"
   utter_ask_hora:
-    - text: "¿A qué hora deseas la cita? (Ejemplo: 10:00, entre 08:00 y 18:00)"
+    - text: "¿A qué hora deseas la cita? Elige una de las horas disponibles (Ejemplo: 10:00)"
   utter_confirmar_cita:
     - text: "Resumen de cita:\nServicio: {servicio}\nFecha: {fecha}\nHora: {hora}\n¿Confirmar?"
   utter_cancelar_cita:


### PR DESCRIPTION
## Summary
- add helper functions to compute available slots and format as table
- display available hours after the user provides the date
- mention available hours in `utter_ask_hora`

## Testing
- `pip install rasa-sdk==3.6.2 rasa==3.6.21 --quiet` *(fails: ERROR: Ignored the...)*

------
https://chatgpt.com/codex/tasks/task_e_6861c1670180832f96cc3ad0c85882a5