### PR TITLE
Implement greeting on session start

### DIFF
--- a/actions/actions.py
+++ b/actions/actions.py
@@ -103,6 +103,19 @@ def tabla_horarios(horarios: List[Text], html: bool = False) -> Text:
 
     return ", ".join(horarios)
 
+
+class ActionSessionStart(Action):
+    """Greets the user once when a new session starts."""
+
+    def name(self) -> Text:
+        return "action_session_start"
+
+    async def run(
+        self, dispatcher: CollectingDispatcher, tracker: Tracker, domain: DomainDict
+    ) -> List[EventType]:
+        dispatcher.utter_message(response="utter_saludo")
+        return [SessionStarted(), ActionExecuted("action_listen")]
+
 class ActionDefaultFallback(Action):
     def name(self) -> str:
         return "action_default_fallback"

--- a/channels.py
+++ b/channels.py
@@ -112,14 +112,7 @@ class CustomSocketIOInput(SocketIOInput):
                 namespace=self.namespace,
             )
 
-            output_channel = CustomSocketIOOutput(sio, self.bot_message_evt)
-            message = UserMessage(
-                "/saludo",
-                output_channel,
-                sender,
-                input_channel=self.name(),
-            )
-            await on_new_message(message)
+
 
         @sio.on(self.user_message_evt, namespace=self.namespace)
         async def handle_message(sid: Text, data: Dict) -> None:

--- a/domain.yml
+++ b/domain.yml
@@ -98,6 +98,7 @@ actions:
   - action_responder_consulta_mecanica
   - action_consultar_cita
   - action_mostrar_historial
+  - action_session_start
 
 session_config:
   session_expiration_time: 7200       # en segundos (2 horas)


### PR DESCRIPTION
## Summary
- greet users when a Rasa session starts
- stop sending `/saludo` from the Socket.IO channel

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861cdff7cd0832f97d76a53170f3ab1