### PR TITLE
Evita citas duplicadas en el mismo horario desde panel admin

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -1019,7 +1019,12 @@
           btn.style.display = 'none';
           tr.querySelector('.edit-cita-btn').style.display = 'inline-block';
         } else {
-          alert('Error al actualizar la cita');
+          let mensaje = 'Error al actualizar la cita';
+          try {
+            const data = await res.json();
+            if (data.error) mensaje = data.error;
+          } catch (_) {}
+          alert(mensaje);
         }
       });
     });
@@ -1056,7 +1061,14 @@
         body: params.toString()
       });
       if (res.ok) location.reload();
-      else alert('Error al agregar cita');
+      else {
+        let mensaje = 'Error al agregar cita';
+        try {
+          const data = await res.json();
+          if (data.error) mensaje = data.error;
+        } catch (_) {}
+        alert(mensaje);
+      }
     });
 
     // — Filtros de Citas —


### PR DESCRIPTION
### Motivation
- Evitar que el panel de administración pueda crear o editar una cita en un bloque de fecha/hora ya ocupado por otra cita activa.
- Centralizar la lógica de detección de conflictos para reutilizarla desde distintos endpoints administrativos.

### Description
- Añadida la función `existe_conflicto_horario(cursor, fecha, hora, excluir_id_cita=None)` en `backend.py` para comprobar si existe una cita ocupando el mismo `fecha`+`hora` con estados activos (`confirmada`, `reprogramada`, `en progreso`).
- Integrada la validación en los endpoints `/admin/agregar_cita` y `/admin/actualizar_cita` para devolver `409` y un mensaje claro cuando el horario está ocupado.
- Mejorado el frontend `frontend/admin.html` para leer y mostrar el mensaje de error JSON que responde el backend al crear o actualizar una cita en caso de conflicto.

### Testing
- Ejecutado `python -m py_compile backend.py` y la compilación del módulo fue exitosa.
- Intento de prueba rápida in-memory de la función de conflicto con un pequeño script Python falló por falta de dependencias del entorno (`ModuleNotFoundError: No module named 'flask'`).
- No se ejecutaron pruebas end-to-end contra el servidor en este entorno; la validación se limitó a comprobaciones estáticas y ajustes del frontend para propagar el mensaje de error del backend.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698aaea3fc6c832fb0bd9715f592fabd)