### PR TITLE
Quitar “Cancelada/Completada” del calendario interactivo en admin

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -607,12 +607,11 @@
           <h2 class="h4 mb-0">Disponibilidad y ocupación de citas</h2>
         </div>
       </div>
-      <p class="text-secondary mb-0">Visualiza bloques disponibles (verde) y citas ocupadas (rojo). Los estados cancelada/completada se muestran en ámbar para referencia.</p>
+      <p class="text-secondary mb-0">Visualiza bloques disponibles (verde) y citas ocupadas (rojo).</p>
       <div id="admin-calendar"></div>
       <div class="calendar-legend">
         <span><span class="legend-dot" style="background:#86efac"></span>Disponible</span>
         <span><span class="legend-dot" style="background:#dc2626"></span>Ocupado</span>
-        <span><span class="legend-dot" style="background:#f59e0b"></span>Cancelada/Completada</span>
       </div>
     </section>
 


### PR DESCRIPTION
### Motivation
- Simplificar la vista del panel administrativo eliminando la referencia y la leyenda `Cancelada/Completada` del bloque "Calendario interactivo / Disponibilidad y ocupación de citas" para mostrar solo los estados relevantes.

### Description
- Se modificó `frontend/admin.html` para eliminar la frase que mencionaba `cancelada/completada` y se quitó el elemento de la leyenda correspondiente, dejando únicamente `Disponible` y `Ocupado` en la interfaz.

### Testing
- Verifiqué la ausencia de la cadena con `rg -n "Cancelada/Completada|cancelada/completada" frontend/admin.html`, levanté un servidor con `python3 -m http.server 4173 --bind 0.0.0.0`, generé una captura de pantalla mediante un script de Playwright y confirmé el cambio con `git commit`, y todas las comprobaciones automatizadas se completaron con éxito.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ab09ed4d0832f9c569a4a6a44cbc3)