### PR TITLE
Traducir calendario interactivo de administración al español

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -698,6 +698,7 @@
   <!-- Bootstrap JS Bundle -->
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.15/index.global.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.15/locales-all.global.min.js"></script>
   <!-- Tu JavaScript CRUD, sin cambios -->
   <script>
     const confirmationModalElement = document.getElementById('confirmationModal');
@@ -872,6 +873,12 @@
     if (calendarElement && window.FullCalendar) {
       const calendar = new FullCalendar.Calendar(calendarElement, {
         locale: 'es',
+        buttonText: {
+          today: 'Hoy',
+          month: 'Mes',
+          week: 'Semana',
+          day: 'Día'
+        },
         initialView: 'timeGridWeek',
         height: 'auto',
         allDaySlot: false,


### PR DESCRIPTION
### Motivation
- Garantizar que el calendario interactivo de la vista de administración muestre la localización en español y que los controles (botones) aparezcan traducidos.

### Description
- Se actualizó `frontend/admin.html` para cargar `locales-all.global.min.js` de FullCalendar y se añadió la opción `buttonText` con las traducciones `Hoy`, `Mes`, `Semana`, `Día` manteniendo `locale: 'es'`.

### Testing
- Se ejecutó `git diff --check` y no reportó errores, se sirvió la aplicación con `python3 -m http.server 4173 --directory /workspace/chatbot-citas-taller`, y se generó una captura de pantalla vía Playwright para verificar la interfaz traducida (éxito).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ab1e69784832fafbc5af810640d81)